### PR TITLE
VotingSession behaviour finaly fixed

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
-  def current_user_voting_session
-    @current_user_voting_session ||= VotingSession.joins(voters: :user).find_by(users: { id: current_user.id })
+  def current_voting_session(user)
+    VotingSession.joins(voters: :user).find_by(users: { id: user.id })
   end  
 
   def current_user_voting_session_as_master
@@ -9,7 +9,7 @@ module ApplicationHelper
 
   def current_user_voted_location
     #@current_user_voting_session ||= VotingSession.find_by(user_id: current_user.id)
-    session = current_user_voting_session
+    session = current_voting_session(current_user)
     vote = Vote.where(voting_session_id: session).group(:special_offer_id).order('COUNT(special_offer_id) DESC').limit(1).count
     sp_offer = SpecialOffer.find(vote.keys.first)
     @current_user_voted_location = sp_offer.restaurant

--- a/app/models/voting_session.rb
+++ b/app/models/voting_session.rb
@@ -14,10 +14,12 @@ class VotingSession < ApplicationRecord
   
   private
   def broadcast_voting_session
-    broadcast_replace_to "votingsession_#{id}_messages",
-                        partial: "shared/iconnav",
-                        target: "iconnav",
-                        locals: { color: "blue"}
+    self.voters.each do |voter| 
+      broadcast_replace_to "votingsession_#{voter.user.id}_messages",
+                          partial: "shared/iconnav",
+                          target: "iconnav",
+                          locals: { voting_session: self }
+      end
   end
 end
 

--- a/app/views/shared/_iconnav.html.erb
+++ b/app/views/shared/_iconnav.html.erb
@@ -1,2 +1,15 @@
-
-  <i id="iconnav" class="fa-solid fa-users fs-1" style="color:<%=color%>"></i>
+<% if voting_session %>
+  <% if voting_session.status == 1 %>
+    <%=link_to voting_session_path(voting_session), class: "btn" do %>
+      <i id="iconnav" class="fa-solid fa-users fs-1 fa-bounce"></i>
+    <%end%>
+  <%elsif voting_session.status == 2 %>
+    <%=link_to voting_session_path(voting_session), class: "btn" do %>
+      <i id="iconnav" class="fa-solid fa-users fs-1"></i>
+    <%end%>
+  <%else%>
+    <i id="iconnav" class="fa-solid fa-users fs-1" style="color:gray"></i>
+  <%end%>
+<% else %>
+  <i id="iconnav" class="fa-solid fa-users fs-1" style="color:gray"></i>
+<% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -16,8 +16,10 @@
       <% if user_signed_in? %>
         <!-- the first voter of a voting session is the "organizer",
         for the organizer the voting session the link/icon displays -->
-        <%= turbo_stream_from "votingsession_#{current_user_voting_session&.id}_messages" %>
-        <%=render 'shared/iconnav', color: current_user_voting_session.nil? ? "gray" : "blue"%>
+        <%= turbo_stream_from "votingsession_#{current_user.id}_messages" %>
+        <span id="iconnav">
+          <%=render 'shared/iconnav', voting_session: current_voting_session(current_user) %>
+        </span>
       <% end %>
       <div>
         <% if user_signed_in?%>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,9 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 
+#Added by chaf, because of Devise issues with current_user helper during tests
+include Devise::Test::ControllerHelpers
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers


### PR DESCRIPTION
- The voting icon on the navbar behaves as follows:
 * gray and not clickable when no voting session for the user or the voting is still under preparation on the organizer side (status=0)
 * black clickable with jumping animation when the organizer opens the voting session opens the vote (status =1)
 * black clickable with no animation if the voting session ended (status = 2)
 * gray not clickable if the vote is closed once for all (status = 3)
- no refresh need thanks to Turbo Streaming for the icon behaviour change every voter can see the behaviour changes live
- I added a configuration due to problem with Devise not linking TurboStreaming partials with current_user helpers inside. Didn't change anything, I had to redesign stuff to make it work.